### PR TITLE
Collision mechanics, resting on surfaces

### DIFF
--- a/Assets/OpenRelativity/Scripts/Objects/RelativisticObject.cs
+++ b/Assets/OpenRelativity/Scripts/Objects/RelativisticObject.cs
@@ -1782,7 +1782,7 @@ namespace OpenRelativity.Objects
             Vector3 finalTanRapidity;
             if (penDist > 0)
             {
-                float impulse = (float)(-hookeMultiplier * combYoungsModulus * penDist * state.FixedDeltaTimePlayer * GetTimeFactor());
+                float impulse = (float)(hookeMultiplier * combYoungsModulus * penDist * state.FixedDeltaTimePlayer * GetTimeFactor());
 
                 Vector3 tanNorm = Vector3.Cross(Vector3.Cross(lineOfAction, relVel), lineOfAction).normalized;
                 Vector3 frictionChange = combFriction * impulse * tanNorm;

--- a/Assets/OpenRelativity/Scripts/Objects/RelativisticObject.cs
+++ b/Assets/OpenRelativity/Scripts/Objects/RelativisticObject.cs
@@ -34,6 +34,10 @@ namespace OpenRelativity.Objects
                     Vector4 playerAccel = state.PlayerAccelerationVector;
                     Vector3 playerAngVel = state.PlayerAngularVelocityVector;
                     Vector4 myAccel = GetTotalAcceleration(piw);
+
+                    //Consider the acceleration in this set operation to happen over the course of one fixed update frame:
+                    myAccel += (Vector4)((value - _viw) * (float)GetTimeFactor() * Time.fixedDeltaTime);
+
                     Matrix4x4 vpcLorentz = state.PlayerLorentzMatrix;
                     //Under instantaneous changes in velocity, the optical position should be invariant:
                     //Vector3 test = piw.WorldToOptical(_viw, playerPos, playerVel);
@@ -229,7 +233,7 @@ namespace OpenRelativity.Objects
         //If we have a Rigidbody, we cache it here
         private Rigidbody myRigidbody;
         //If we have a Renderer, we cache it, too.
-        public Renderer myRenderer;
+        public Renderer myRenderer { get; set; }
         //Did we collide last frame?
         private bool didCollide;
         //What was the translational velocity result?
@@ -1054,7 +1058,7 @@ namespace OpenRelativity.Objects
                     gameObject.layer = myLayer;
                 }
 
-                if (!isStatic && myRigidbody != null)
+                if (!isStatic && !isSleeping && myRigidbody != null)
                 {
                     //update our viw and set the rigid body proportionally
                     //Dragging probably happens intrinsically in the rest frame,
@@ -1084,7 +1088,8 @@ namespace OpenRelativity.Objects
                                 Ray down = new Ray(opticalWorldCenterOfMass, Vector3.down);
                                 float extentY = myColliders[0].bounds.extents.y;
                                 RaycastHit hitInfo;
-                                if (Physics.Raycast(down, out hitInfo, (transform.position - transform.TransformPoint(Vector3.down * extentY)).magnitude + 0.01f))
+                                float distance = (transform.position - transform.TransformPoint(Vector3.down * extentY)).magnitude;
+                                if (Physics.Raycast(down, out hitInfo, distance + 0.01f))
                                 {
                                     sleepFrameCounter = sleepFrameDelay;
                                     Sleep();


### PR DESCRIPTION
While some physical accuracy might have to be sacrificed, it would be nice if box colliders could come to rest on flat surfaces in a way that feels intuitive enough for game mechanics.

A couple of tweaks to the rigid body physics enables this behavior:
- When the velocity setter is called, this implies a proper acceleration, which must be accounted for, for the Lorentz transformation in Rindler metric. (This change should increase overall relativistic accuracy.)
- When the "Nonrelativistic Collider" option is used, the "Contractor" parent transform "wiggles" the object on any surface it rests on, in a way that makes it spin and "pop." We turn off the "Contractor" if the object `isSleeping`. (This is less accurate, but necessary. Anyway, this option is an approximation that works best only when used with small props.)